### PR TITLE
Fixed the bug with 0-arity interface methods + added some more settings + refactorings

### DIFF
--- a/Assets/Plugins/CommentToTooltip/CodeProcessingConfiguration.cs
+++ b/Assets/Plugins/CommentToTooltip/CodeProcessingConfiguration.cs
@@ -1,4 +1,9 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+using UnityEngine;
 
 namespace ToolBuddy.CommentToTooltip
 {
@@ -17,25 +22,52 @@ namespace ToolBuddy.CommentToTooltip
         /// Regex that transform documentation lines to comment lines.
         /// Is optional: If no documentation to comment transformation needed, set this to null
         /// </summary>
+        [CanBeNull]
         internal Regex CommentExtractor { get; private set; }
 
         /// <summary>
-        /// A list of file extensions - spearated with an ';' -  that will be considered in the code processing
+        /// Read-only collection of strings indicating the file extensions that will be considered by the code processing.
         /// </summary>
-        internal string CompatibleFileExtensions { get; private set; }
+        internal IReadOnlyCollection<string> CompatibleFileExtensions { get; private set; }
 
         /// <summary>
         /// The <see cref="CommentTypes"/> that are processed by this code processor
         /// </summary>
         internal CommentTypes CommentTypes { get; private set; }
 
-        internal CodeProcessingConfiguration(Regex parser, Regex commentExtractor, string compatibleFileExtensions, CommentTypes commentType)
+        internal bool CanIProcessThisExt(string ext)
+        {
+            return CompatibleFileExtensions.Contains(ext.ToLowerInvariant());
+        }
+        
+
+        /// <summary>
+        /// refactored constructor
+        /// </summary>
+        /// <param name="parser">thing that extracts from the code documentation lines</param>
+        /// <param name="commentExtractor">regex for extracting the summary from summary tags (optional) </param>
+        /// <param name="commentTypes">supported comment types for parsing</param>
+        /// <param name="compatibleFileExtensions">filetypes that this is compatible with</param>
+        internal CodeProcessingConfiguration(
+            Regex parser,
+            [CanBeNull] Regex commentExtractor,
+            CommentTypes commentTypes,
+            params string[] compatibleFileExtensions
+        )
         {
             Parser = parser;
             CommentExtractor = commentExtractor;
-            CompatibleFileExtensions = compatibleFileExtensions;
-            CommentTypes = commentType;
+            CommentTypes = commentTypes;
+            HashSet<string> exts = new HashSet<string>();
+            foreach (var ext in compatibleFileExtensions)
+            {
+                exts.Add($".{ext.ToLowerInvariant()}");
+            }
+            exts.TrimExcess();
+            CompatibleFileExtensions = exts;
         }
+        
+        
     }
     /*! \endcond */
 }

--- a/Assets/Plugins/CommentToTooltip/CodeProcessingConfiguration.cs
+++ b/Assets/Plugins/CommentToTooltip/CodeProcessingConfiguration.cs
@@ -1,9 +1,6 @@
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
-using JetBrains.Annotations;
-using UnityEngine;
 
 namespace ToolBuddy.CommentToTooltip
 {
@@ -22,7 +19,6 @@ namespace ToolBuddy.CommentToTooltip
         /// Regex that transform documentation lines to comment lines.
         /// Is optional: If no documentation to comment transformation needed, set this to null
         /// </summary>
-        [CanBeNull]
         internal Regex CommentExtractor { get; private set; }
 
         /// <summary>
@@ -50,7 +46,7 @@ namespace ToolBuddy.CommentToTooltip
         /// <param name="compatibleFileExtensions">filetypes that this is compatible with</param>
         internal CodeProcessingConfiguration(
             Regex parser,
-            [CanBeNull] Regex commentExtractor,
+            Regex commentExtractor,
             CommentTypes commentTypes,
             params string[] compatibleFileExtensions
         )

--- a/Assets/Plugins/CommentToTooltip/CommentTypes.cs
+++ b/Assets/Plugins/CommentToTooltip/CommentTypes.cs
@@ -13,17 +13,18 @@ namespace ToolBuddy.CommentToTooltip
         /// </summary>
         None = 0,
         /// <summary>
-        /// Comments of type: \verbatim/// <summary> something </summary>\endverbatim
+        /// Comments of type: verbatim /// <summary> something </summary> \endverbatim
         /// More information can be found in the Annex E: "Documentation Comments" of the C# Language specification
         /// </summary>
         SingleLineDocumentation = 1 << 0,
         /// <summary>
-        /// Comments of type: \verbatim/**<summary> Comment here </summary>*/ \endverbatim
+        /// Comments of type: \verbatim /**<summary> Comment here </summary>*/ \endverbatim
         /// More information can be found in the Annex E: "Documentation Comments" of the C# Language specification
         /// </summary>
         DelimitedDocumentation = 1 << 1,
         /// <summary>
-        /// Comments of type: \verbatim// Comment here \endverbatim
+        /// Comments of type: \verbatim // Comment here \endverbatim
+        /// </summary>
         SingleLine = 1 << 2,
 
         // <summary>

--- a/Assets/Plugins/CommentToTooltip/Editor/Menu.cs
+++ b/Assets/Plugins/CommentToTooltip/Editor/Menu.cs
@@ -13,7 +13,7 @@ namespace ToolBuddy.CommentToTooltip.Editor
 {
     public static class Menu
     {
-        static private readonly TooltipGenerator tooltipGenerator = new TooltipGenerator();
+        private static readonly TooltipGenerator tooltipGenerator = new TooltipGenerator();
 
         #region editor settings
         static private readonly Settings settings = new Settings();

--- a/Assets/Plugins/CommentToTooltip/Editor/Settings.cs
+++ b/Assets/Plugins/CommentToTooltip/Editor/Settings.cs
@@ -7,16 +7,30 @@ namespace ToolBuddy.CommentToTooltip.Editor
         private const string editorPreferencesKey1 = "C2T_SingleLineDocumentation";
         private const string editorPreferencesKey2 = "C2T_DelimitedDocumentation";
         private const string editorPreferencesKey3 = "C2T_SingleLine";
+        private const string editorPreferencesKey4 = "C2T_LogFile";
+        private const string editorPreferencesKey5 = "C2T_LogExceptionsFile";
 
         public bool ParseSingleLineDocumentationComments { get; set; }
         public bool ParseDelimitedDocumentationComments { get; set; }
         public bool ParseSingleLineComments { get; set; }
+        
+        /// <summary>
+        /// allows the user to toggle whether or not they want to log stuff to 'Comment To Tooltips_log.txt'
+        /// </summary>
+        public bool EnableLoggingToFile { get; set; }
+        
+        /// <summary>
+        /// allows exceptions to be logged to file regardless of whether or not everything else is logged.
+        /// </summary>
+        public bool EnableLoggingExceptionsToFile { get; set; }
 
         public void ReadFromEditorPreferences()
         {
             ParseSingleLineDocumentationComments = EditorPrefs.GetBool(editorPreferencesKey1, true);
             ParseDelimitedDocumentationComments = EditorPrefs.GetBool(editorPreferencesKey2, true);
             ParseSingleLineComments = EditorPrefs.GetBool(editorPreferencesKey3, true);
+            EnableLoggingToFile = EditorPrefs.GetBool(editorPreferencesKey4, true);
+            EnableLoggingExceptionsToFile = EditorPrefs.GetBool(editorPreferencesKey5, true);
         }
 
         public void WriteToEditorPreferences()
@@ -24,17 +38,19 @@ namespace ToolBuddy.CommentToTooltip.Editor
             EditorPrefs.SetBool(editorPreferencesKey1, ParseSingleLineDocumentationComments);
             EditorPrefs.SetBool(editorPreferencesKey2, ParseDelimitedDocumentationComments);
             EditorPrefs.SetBool(editorPreferencesKey3, ParseSingleLineComments);
+            EditorPrefs.SetBool(editorPreferencesKey4, EnableLoggingToFile);
+            EditorPrefs.SetBool(editorPreferencesKey5, EnableLoggingToFile || EnableLoggingExceptionsToFile);
         }
 
         public CommentTypes GetCommenTypes()
         {
             CommentTypes result = CommentTypes.None;
             if (ParseSingleLineDocumentationComments)
-                result = result | CommentTypes.SingleLineDocumentation;
+                result |= CommentTypes.SingleLineDocumentation;
             if (ParseDelimitedDocumentationComments)
-                result = result | CommentTypes.DelimitedDocumentation;
+                result |= CommentTypes.DelimitedDocumentation;
             if (ParseSingleLineComments)
-                result = result | CommentTypes.SingleLine;
+                result |= CommentTypes.SingleLine;
             return result;
         }
     }

--- a/Assets/Plugins/CommentToTooltip/Editor/SettingsWindow.cs
+++ b/Assets/Plugins/CommentToTooltip/Editor/SettingsWindow.cs
@@ -10,6 +10,10 @@ namespace ToolBuddy.CommentToTooltip.Editor
         private const string toggle2Text = @"/**<summary> Comment here </summary>*/";
         private const string toggle3Text = @"// Comment here";
 
+        private const string enableLogsLabel = "Logging";
+        private const string enableLogsToggleText = "Log all messages to Assets/Comment To Tooltip_logs.txt";
+        private const string enableExceptionLogsToggleText = "Log all exceptions to Assets/Comment To Tooltip_logs.txt";
+
         public SettingsWindow()
         {
             minSize = new Vector2(350, 100);
@@ -19,11 +23,27 @@ namespace ToolBuddy.CommentToTooltip.Editor
         {
             GUILayout.Label(label, EditorStyles.boldLabel);
 
-            EditorGUIUtility.labelWidth = EditorGUIUtility.currentViewWidth * 0.9f;
+            var bigLabelWidth = EditorGUIUtility.labelWidth;
+            var smallLabelWidth = EditorGUIUtility.currentViewWidth * 0.9f;
+            
+            EditorGUIUtility.labelWidth = smallLabelWidth;
 
             Menu.Settings.ParseSingleLineDocumentationComments = EditorGUILayout.Toggle(toggle1Text, Menu.Settings.ParseSingleLineDocumentationComments);
             Menu.Settings.ParseDelimitedDocumentationComments = EditorGUILayout.Toggle(toggle2Text, Menu.Settings.ParseDelimitedDocumentationComments);
             Menu.Settings.ParseSingleLineComments = EditorGUILayout.Toggle(toggle3Text, Menu.Settings.ParseSingleLineComments);
+
+            EditorGUIUtility.labelWidth = bigLabelWidth;
+            
+            GUILayout.Label(enableLogsLabel, EditorStyles.boldLabel);
+            EditorGUIUtility.labelWidth = smallLabelWidth;
+
+            Menu.Settings.EnableLoggingToFile = EditorGUILayout.Toggle(enableLogsToggleText, Menu.Settings.EnableLoggingToFile);
+            Menu.Settings.EnableLoggingExceptionsToFile = EditorGUILayout.Toggle(
+                enableExceptionLogsToggleText,
+                Menu.Settings.EnableLoggingExceptionsToFile
+            );
+
+
         }
 
         public void OnFocus()

--- a/Assets/Plugins/CommentToTooltip/ReadMe.txt
+++ b/Assets/Plugins/CommentToTooltip/ReadMe.txt
@@ -3,6 +3,8 @@
 // All rights reserved
 // 
 // http://www.toolbuddy.net
+//
+//
 // =====================================================================
 
 USAGE
@@ -21,4 +23,11 @@ This asset is subject to Unity's standard Unity Asset Store End User License Agr
 
 Contact & Support
 =================
-If you have any questions, feedback or requests, please write to admin@curvyeditor.com 
+If you have any questions, feedback or requests, please write to admin@toolbuddy.net 
+
+
+------
+changelog (11BelowStudio, 18/5/2022):
+* no longer accidentally addds tooltips to 0-arity interface methods
+* can enable/disable logging all info to a file (can toggle logging exceptions to the file seperately)
+* a few bits of code cleanup/refactoring/nicer outputs for the end user

--- a/Assets/Plugins/CommentToTooltip/TooltipGenerator.cs
+++ b/Assets/Plugins/CommentToTooltip/TooltipGenerator.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using JetBrains.Annotations;
 
 namespace ToolBuddy.CommentToTooltip
 {

--- a/Assets/Plugins/CommentToTooltip/TooltipGenerator.cs
+++ b/Assets/Plugins/CommentToTooltip/TooltipGenerator.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using JetBrains.Annotations;
 
 namespace ToolBuddy.CommentToTooltip
 {
@@ -12,12 +14,16 @@ namespace ToolBuddy.CommentToTooltip
     /// </summary>
     public class TooltipGenerator
     {
+        
         private readonly StringBuilder tooltipTagBuilder;
         private readonly StringBuilder documentationBuilder;
 
         private readonly List<CodeProcessingConfiguration> codeProcessors;
         private readonly string escapedNewLineInGeneratedCode;
         private readonly string newLineInGeneratedCode;
+        
+        
+        
 
         /// <summary>
         /// Creates a new instance.
@@ -37,9 +43,11 @@ namespace ToolBuddy.CommentToTooltip
             string doubleEscapedNewLine = newLineInGeneratedCode.Replace("\r", @"\\r");
             doubleEscapedNewLine = doubleEscapedNewLine.Replace("\n", @"\\n");
 
-            Regex commentExtractingRegexp =
-                new Regex(@"\s*<summary>\s*(?:" + doubleEscapedNewLine + @")?(?<comment>.*?(?=(?:" + doubleEscapedNewLine + @")?\s*</summary\s*))",
-                    regexOptions);
+            Regex summaryCommentExtractorRegexp =
+                new Regex(
+                    $@"\s*<summary>\s*(?:{doubleEscapedNewLine})?(?<comment>.*?(?=(?:{doubleEscapedNewLine})?\s*</summary\s*))",
+                    regexOptions
+                );
 
 
             /* capture groups:
@@ -50,33 +58,58 @@ namespace ToolBuddy.CommentToTooltip
             field => field declaration
             */
 
+            
             const string nonTooltipAttributes =
                 @"(?<attributes>^[ \t]*\[(?!([ \t]*(?:UnityEngine.)?Tooltip))[^]]+\]\s*(?=^))*";
             const string nonCommentRegexPart =
-                @"\s*(?=^)" + nonTooltipAttributes + @"(?<tooltip>^[ \t]*\[(?:UnityEngine.)?Tooltip\(""(?<tooltipContent>[^""]*)""\)\]\s*(?=^))?" + nonTooltipAttributes + @"(?<field>(?<beginning>^[ \t]*)public\s+[^\s;=]+\s+[^\s;=]+\s*(?>=[^;]+)?;)";
+                @"\s*(?=^)" + 
+                nonTooltipAttributes + 
+                @"(?<tooltip>^[ \t]*\[(?:UnityEngine.)?Tooltip\(""(?<tooltipContent>[^""]*)""\)\]\s*(?=^))?"
+                + nonTooltipAttributes + 
+                @"(?<field>(?<beginning>^[ \t]*)public\s+[^\s;=]+\s+[^\s;=\\(]+\s*(?>=[^;]+)?;)";
 
 
             string newLineRegex = @"(?:\r)?\n";
-            CodeProcessingConfiguration singleLineDocCommentCSharpProcessingConfiguration = new CodeProcessingConfiguration(new Regex(
-                @"(?>^[ \t]*///[ \t]?(?>(?<documentation>[^\r\n]*))" + newLineRegex + @")+" + nonCommentRegexPart,
-                regexOptions), commentExtractingRegexp, "cs", CommentTypes.SingleLineDocumentation);
+            CodeProcessingConfiguration singleLineDocCommentCSharpProcessingConfiguration = new CodeProcessingConfiguration(
+                new Regex(
+                    $@"(?>^[ \t]*///[ \t]?(?>(?<documentation>[^\r\n]*)){newLineRegex})+{nonCommentRegexPart}", 
+                    regexOptions
+                ), 
+                summaryCommentExtractorRegexp,
+                CommentTypes.SingleLineDocumentation,
+                "cs"
+            );
 
-            CodeProcessingConfiguration delimitedDocCommentCSharpProcessingConfiguration = new CodeProcessingConfiguration(new Regex(
-                @"(?>^[ \t]*/\*)(?:(?>[ \t]*\*[ \t]?)(?<documentation>[^\r\n]*)(?:" + newLineRegex + @")?)+[ \t]*\*/[ \t]*" + newLineRegex + @"" + nonCommentRegexPart,
-                regexOptions), commentExtractingRegexp, "cs", CommentTypes.DelimitedDocumentation);
+            CodeProcessingConfiguration delimitedDocCommentCSharpProcessingConfiguration = new CodeProcessingConfiguration(
+                new Regex(
+                    $@"(?>^[ \t]*/\*)(?:(?>[ \t]*\*[ \t]?)(?<documentation>[^\r\n]*)(?:{newLineRegex})?)+[ \t]*\*/[ \t]*{newLineRegex}{nonCommentRegexPart}",
+                    regexOptions
+                ), 
+                summaryCommentExtractorRegexp,
+                CommentTypes.DelimitedDocumentation,
+                "cs"
+            );
 
-            CodeProcessingConfiguration singleLineCommentProcessingConfiguration = new CodeProcessingConfiguration(new Regex(
-                @"(?>^[ \t]*//(?!/)[ \t]?(?>(?<documentation>[^\r\n]*))" + newLineRegex + @")+" + nonCommentRegexPart,
-                regexOptions), null, "cs;js", CommentTypes.SingleLine);
+            CodeProcessingConfiguration singleLineCommentProcessingConfiguration = new CodeProcessingConfiguration(
+                new Regex(
+                    $@"(?>^[ \t]*//(?!/)[ \t]?(?>(?<documentation>[^\r\n]*)){newLineRegex})+{nonCommentRegexPart}", 
+                    regexOptions
+                ), 
+                null,
+                CommentTypes.SingleLine,
+                "cs","js"
+            );
 
             //CodeProcessingConfiguration delimitedCommentProcessingConfiguration = new CodeProcessingConfiguration(new Regex(
             //    @"(?>^[ \t]*/\*)(?:[ \t]*(?=[^[ \t]])(?<documentation>[^\r\n]*)(?:" + caca + @")?)+[ \t]*\*/[ \t]*" + caca + @"" + nonCommentRegexPart,
-            //    regexOptions), null, "cs;js", CommentTypes.Delimited);
+            //    regexOptions), null, CommentTypes.Delimited, "cs", "js");
 
-            codeProcessors = new List<CodeProcessingConfiguration>();
-            codeProcessors.Add(singleLineDocCommentCSharpProcessingConfiguration);
-            codeProcessors.Add(delimitedDocCommentCSharpProcessingConfiguration);
-            codeProcessors.Add(singleLineCommentProcessingConfiguration);
+            codeProcessors = new List<CodeProcessingConfiguration>
+            {
+                singleLineDocCommentCSharpProcessingConfiguration,
+                delimitedDocCommentCSharpProcessingConfiguration,
+                singleLineCommentProcessingConfiguration
+            };
             //codeProcessors.Add(delimitedCommentProcessingConfiguration);
         }
 
@@ -125,14 +158,18 @@ namespace ToolBuddy.CommentToTooltip
         /// <returns> True if an output file with updated content was created. </returns>
         public bool TryProcessFile(string inputFilePath, string outputFilePath, Encoding fileEncoding, CommentTypes commentTypes)
         {
-            String inputFileContent;
+            string inputFileContent;
             using (StreamReader streamReader = new StreamReader(inputFilePath, fileEncoding))
             {
                 inputFileContent = streamReader.ReadToEnd();
             }
 
-            string outputFileContent;
-            bool fileWasModified = TryProcessText(inputFileContent, out outputFileContent, commentTypes);
+            bool fileWasModified = TryProcessText(
+                inputFilePath, 
+                inputFileContent, 
+                out string outputFileContent, 
+                commentTypes
+            );
 
             if (fileWasModified)
             {
@@ -148,11 +185,12 @@ namespace ToolBuddy.CommentToTooltip
         /// <summary>
         /// Processes the given text by updating it with tooltips generated from valid comments.
         /// </summary>
+        /// <param name="fileExtension">extension of the file (used to ensure that it's compatible with the code processors)</param>
         /// <param name="textToProcess"> The input text. </param>
         /// <param name="processedText"> The output text. If method returns false, this text will be equal to <paramref name="textToProcess"/>. </param>
         /// <param name="commentTypes"> The <see cref="CommentTypes"/> to be considered while generating the tooltips. </param>
         /// <returns> True if the text was updated.</returns>
-        public Boolean TryProcessText(string textToProcess, out string processedText, CommentTypes commentTypes)
+        public Boolean TryProcessText(string fileExtension, string textToProcess, out string processedText, CommentTypes commentTypes)
         {
             processedText = textToProcess;
 
@@ -160,8 +198,10 @@ namespace ToolBuddy.CommentToTooltip
 
             foreach (CodeProcessingConfiguration codeProcessor in codeProcessors)
             {
-                if ((codeProcessor.CommentTypes & commentTypes) == CommentTypes.None)
+                if ((codeProcessor.CommentTypes & commentTypes) == CommentTypes.None ||
+                    !codeProcessor.CanIProcessThisExt(fileExtension))
                     continue;
+                
 
                 int insertedTextLength = 0;
                 MatchCollection matches = codeProcessor.Parser.Matches(processedText);
@@ -230,7 +270,12 @@ namespace ToolBuddy.CommentToTooltip
                 //extracting the significant meaningful part of the documentation
                 Match match = commentExtractor.Match(documentation);
                 if (match.Success == false)
-                    throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, "Could not parse the following documentation xml '{0}'", documentation));
+                    throw new InvalidOperationException(
+                        String.Format(
+                            CultureInfo.InvariantCulture,
+                            "Could not parse the following documentation xml '{0}'", documentation
+                            )
+                        );
                 tooltipContent = match.Groups["comment"].ToString();
             }
             else


### PR DESCRIPTION
* no longer accidentally addds tooltips to 0-arity interface methods (see #1 )
* can enable/disable logging all info to a file (can toggle logging exceptions to the file seperately)
* a few bits of code cleanup/refactoring/nicer outputs for the end user

tested on Unity 2020.3.15f2, and it's been working without issues on my end.